### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Welcome to the repository for the deRSE Unconference 2023 break-out sessions.
 ## Form the program
 
 We will form the program of this event together :handshake: 
-Please post ideas for sessions as [issues](). You need to have a GitHub account in order to do so.
+Please post ideas for sessions as [issues](https://github.com/DE-RSE/un-deRSE23-breakouts/issues). You need to have a GitHub account in order to do so.
 
 - :bulb: Open a new issue for a new idea.
 - :cherries: Comment on existing issues if you have any thoughts or questions about it. You can also mention how you could contribute or anything else relevant to the break-out idea.


### PR DESCRIPTION
Updated the link to for issues/new BO-Sessions to point to the de-RSE-Repo

I assume, that this is the "correct" link (instead of Heidis), as on Sciencesconf the link also directs to the de-RSE-Repo

Should resolve #1 https://github.com/HeidiSeibold/un-deRSE23-breakouts/issues/1